### PR TITLE
unlock accounts on dev and test images

### DIFF
--- a/geth-devnet/devnet.sh
+++ b/geth-devnet/devnet.sh
@@ -9,4 +9,4 @@ if [ ! -f ~/.primaryaccount ]; then
     geth --dev --password ~/.accountpassword account new > ~/.primaryaccount
 fi
 
-geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --rpcapi "db,eth,net,web3,personal" --dev --password ~/.accountpassword --mine --minerthreads 1 --extradata "Kunstmaan"
+geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --rpcapi "db,eth,net,web3,personal" --dev --password ~/.accountpassword --unlock 0 --mine --minerthreads 1 --extradata "Kunstmaan"

--- a/geth-testnet/testnet.sh
+++ b/geth-testnet/testnet.sh
@@ -9,4 +9,4 @@ if [ ! -f ~/.primaryaccount ]; then
     geth --testnet --password ~/.accountpassword account new > ~/.primaryaccount
 fi
 
-geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --testnet --password ~/.accountpassword --mine --minerthreads 1 --extradata "Kunstmaan"
+geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --testnet --password ~/.accountpassword --unlock 0 --mine --minerthreads 1 --extradata "Kunstmaan"


### PR DESCRIPTION
@roderik 

The accounts are locked by default which makes it impossible to deploy
dapps. Since the password is essentially random and hidden there is no way
to unlock the account for testing programs. This unlocks the dev and test
accounts when run so you can fully test your dapps.

I'm not sure what other side effects there are from this or how you were dealing with locked accounts so far but after this change I was able to use truffle to successfully migrate my app.

```
$ truffle migrate
```