### PR TITLE
Enable RPC over WebSockets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,5 @@ devnet:
   tty: true
   expose:
     - 8545
+    - 8546
     - 30303

--- a/geth-devnet/devnet.sh
+++ b/geth-devnet/devnet.sh
@@ -9,4 +9,4 @@ if [ ! -f ~/.primaryaccount ]; then
     geth --dev --password ~/.accountpassword account new > ~/.primaryaccount
 fi
 
-geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --rpcapi "db,eth,net,web3,personal" --dev --password ~/.accountpassword --mine --minerthreads 1 --extradata "Kunstmaan"
+geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --rpcapi "db,eth,net,web3,personal" --ws --wsaddr "0.0.0.0" --wsorigins "*" --wsapi "db,eth,net,web3,personal" --dev --password ~/.accountpassword --mine --minerthreads 1 --extradata "Kunstmaan"

--- a/geth-testnet/testnet.sh
+++ b/geth-testnet/testnet.sh
@@ -9,4 +9,4 @@ if [ ! -f ~/.primaryaccount ]; then
     geth --testnet --password ~/.accountpassword account new > ~/.primaryaccount
 fi
 
-geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --testnet --password ~/.accountpassword --mine --minerthreads 1 --extradata "Kunstmaan"
+geth --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --ws --wsaddr "0.0.0.0" --wsorigins "*" --testnet --password ~/.accountpassword --mine --minerthreads 1 --extradata "Kunstmaan"


### PR DESCRIPTION
Enables RPC over WebSockets, so it is possible to subscribe to events with Web3 1.0.0.